### PR TITLE
docs: include Brainrot in language list

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A collection of programs in different programming languages that ask for your na
 - Bash
 - Befunge
 - Brainfuck
+- Brainrot
 - C
 - C++
 - Go


### PR DESCRIPTION
## Summary
- document Brainrot language option in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689be58a32e883218747cf5b4663ba6d